### PR TITLE
Set yarn workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "bugs": "https://github.com/Jeeiii/mpc-phase2-suite/issues",
   "license": "MIT",
   "private": true,
+  "workspaces": ["cli", "firebase"],
   "keywords": [
     "typescript",
     "zero-knowledge",


### PR DESCRIPTION
Currently, running `tsc` in `firebase` sub-package fails with missing module('chai', 'chai-as-promise'...etc) error. To fix it, this PR sets yarn workspaces to the root package to link modules.

Running `yarn install` in the project root will install all project dependencies and will link its dependencies together. (see: https://classic.yarnpkg.com/lang/en/docs/workspaces/) 