### PR TITLE
Add a CI workflow to deploy dev environment

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,23 @@
+name: Deploy - dev environment
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+
+      - name: Install Dependencies
+        run: yarn install
+
+      - name: Deploy to Firebase
+        run: yarn firebase:deploy
+        working-directory: firebase
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}

--- a/firebase/firebase.json
+++ b/firebase/firebase.json
@@ -32,8 +32,5 @@
     "ui": {
       "enabled": true
     }
-  },
-  "remoteconfig": {
-    "template": "remoteconfig.template.json"
   }
 }


### PR DESCRIPTION
When a push event occurred to the `dev` branch, then CI will build the source of the `firebase` sub-package and deploy it to the `dev` environment (project: `mpc-phase2-suite-test`).

blocked by: https://github.com/quadratic-funding/mpc-phase2-suite/pull/38