### PR TITLE
fix: fix failure of yarn install command when using Node.js v18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ yarn-error.log
 
 # test coverage
 coverage/
+
+.DS_Store
+
+.gcloudignore

--- a/firebase/package.json
+++ b/firebase/package.json
@@ -14,7 +14,7 @@
   "types": "dist/types/src/index.d.ts",
   "type": "module",
   "engines": {
-    "node": "16"
+    "node": ">=16.14.0"
   },
   "files": [
     "dist/",


### PR DESCRIPTION
[CI build had been failed](https://github.com/quadratic-funding/mpc-phase2-suite/actions/runs/3541603121/jobs/5946067910) due to `engines.node` value of `package.json` has been set to `16`. Fix it's value based on the [documentation](https://github.com/quadratic-funding/mpc-phase2-suite/blob/4071db858582cc34604b81763c079a17f82e4c06/README.md#prerequisities).