### PR TITLE
chore: add a pre-commit hook to enforce linting automatically

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx lint-staged

--- a/README.md
+++ b/README.md
@@ -88,3 +88,18 @@ What's missing
 -   Support
 
 **Please, follow the project boards to stay up-to-date!**
+
+## Pre-commit hook
+
+Our repository uses a pre-commit hook to automatically check for linting rule and code style compliance using ESLint and Prettier whenever a git commit command is executed. In addition, it will automatically fix any violations it finds. This ensures that all code committed to the repository follows a consistent style and adheres to best practices for readability and maintainability.
+
+
+To skip a pre-commit hook and proceed with the commit without running the hook's checks, you can use the --no-verify option when running the git commit command. This will bypass the hook and allow the commit to be made without running any tests or checks.
+
+For example, to commit your changes without running the pre-commit hook, you could use the following command:
+
+```
+git commit --no-verify
+```
+
+Please note that bypassing the pre-commit hook in this way can result in incomplete or incorrect code being added to the repository, so it should only be used in exceptional circumstances.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
         "prettier": "prettier -c .",
         "prettier:fix": "prettier -w .",
         "precommit": "lint-staged",
-        "commit": "cz"
+        "commit": "cz",
+        "prepare": "husky install"
     },
     "devDependencies": {
         "@babel/core": "^7.20.2",
@@ -53,6 +54,7 @@
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-jest": "^27.1.5",
+        "husky": "^8.0.2",
         "jest": "^29.3.1",
         "jest-config": "^29.3.1",
         "lerna": "^6.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10776,6 +10776,11 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
+husky@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.2.tgz#5816a60db02650f1f22c8b69b928fd6bcd77a236"
+  integrity sha512-Tkv80jtvbnkK3mYWxPZePGFpQ/tT3HNSs/sasF9P2YfkMezDl3ON37YN6jUUI4eTg5LcyVynlb6r4eyvOmspvg==
+
 iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"


### PR DESCRIPTION
This PR updates the pre-commit hook to automatically run lint-staged whenever a git commit command is executed. This will ensure that linting and code style checks are performed on all staged files, ensuring that only compliant code is committed to the repository.