### PR TITLE
ci: publish latest development to npm

### DIFF
--- a/.github/workflows/test-ci.yaml
+++ b/.github/workflows/test-ci.yaml
@@ -36,3 +36,35 @@ jobs:
           FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}
           FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
           FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
+
+
+  npm-publish:
+    needs: unit-e2e-test
+    if: ${{ github.event_name == 'push' }}
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use Node.js 16
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Initialize Project
+        run: |
+          yarn install --frozen-lockfile --production
+          yarn build
+
+      - name: Publish Project
+        run: |
+          # Prevent `git commit error` when running `lerna version`
+          # It will not pushed to GitHub. It is ephemeral
+          git config --global user.email "you@example.com"
+          git config --global user.name "Your Name"
+
+          lerna version 0.0.0-ci.$(git rev-parse --short HEAD) --no-push --yes
+          lerna publish from-git --dist-tag ci --yes
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This PR introduces a new CI feature that automatically publishes changed npm packages when code is pushed to the main or dev branch. The features of `dev` branch, which contains the latest merged PR, can be imported using the ci tag in the package.json file, as shown below:

```
"dependencies": {
        "@zkmpc/actions": "ci",
        "@zkmpc/backend": "ci",
        "@zkmpc/phase2cli": "ci",
}
```
Alternatively, you can use the `0.0.0-ci.${COMMITHASH}` tag to import a specific commit, such as` 0.0.0-ci.90b1965.`

### Motivation

>  Ensure that every commit to version control triggers the automated creation of packages that can be deployed to any environment using only information in version control.
[source](https://cloud.google.com/architecture/devops/devops-tech-version-control)
 


