### PR TITLE
Add automation for conventional commit format 

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx --no -- commitlint --edit 

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+exec < /dev/tty && git cz --hook || true

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+module.exports = { extends: ["@commitlint/config-conventional"] }


### PR DESCRIPTION
* Commit will aborted when commit message doesn't meet [conventional commit format](https://www.conventionalcommits.org/en/v1.0.0/)
e.g. `git commit -m "I'm a cowboy"` command will fails with following output:

```
⧗   input: w
✖   subject may not be empty [subject-empty]
✖   type may not be empty [type-empty]

✖   found 2 problems, 0 warnings
ⓘ   Get help: https://github.com/conventional-changelog/commitlint/#what-is-commitlint

husky - commit-msg hook exited with code 1 (error)
```

* `git commit` command will run [commitizen](https://github.com/commitizen/cz-cli) prompt to ensure conventional commit format