### PR TITLE
Firebase Emulator

### DIFF
--- a/.github/workflows/test-ci-dev.yaml
+++ b/.github/workflows/test-ci-dev.yaml
@@ -1,0 +1,22 @@
+name: Run Test <Dev>
+run-name: Test Dev
+
+on:
+  pull_request:
+
+jobs:
+  unit-e2e-test:
+    name: Unit and E2E Test <Dev>
+    runs-on: ubuntu-22.04
+    steps:
+      - name: checkout repo
+        uses: actions/checkout@v3
+
+      - name: install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: run test (unit & e2e)
+        run: yarn test:ci-dev
+        env:
+          FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
+          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}

--- a/.github/workflows/test-ci-dev.yaml
+++ b/.github/workflows/test-ci-dev.yaml
@@ -18,11 +18,10 @@ jobs:
       - name: Get Library Versions For Binary Caching
         id: cache-settings
         run: |
-          echo "::set-output name=firebase-tools::$(yarn list -s --depth=0 --pattern firebase-tools | tail -n 1 | sed 's/.*@//g')"
-          echo "::set-output name=firebase-tools::$(npm list -s --depth=0 | grep firebase-tools | tail -n 1 | sed 's/.*@//g')"
+          echo "FIREBASE_TOOLS=$(yarn list -s --depth=0 --pattern firebase-tools | tail -n 1 | sed 's/.*@//g')" >> $GITHUB_OUTPUT        
 
       - name: Cache Firebase Emulator Binaries
-        uses: actions/cache@v2.1.2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/firebase/emulators
           key: ${{ runner.os }}-firebase-${{ steps.cache-settings.outputs.firebase-tools }}

--- a/.github/workflows/test-ci-dev.yaml
+++ b/.github/workflows/test-ci-dev.yaml
@@ -16,7 +16,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: run test (unit & e2e)
-        run: yarn test:ci-dev
+        run: yarn test:dev
         env:
           FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
           FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}

--- a/.github/workflows/test-ci-dev.yaml
+++ b/.github/workflows/test-ci-dev.yaml
@@ -15,6 +15,18 @@ jobs:
       - name: install dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Get Library Versions For Binary Caching
+        id: cache-settings
+        run: |
+          echo "::set-output name=firebase-tools::$(yarn list -s --depth=0 --pattern firebase-tools | tail -n 1 | sed 's/.*@//g')"
+          echo "::set-output name=firebase-tools::$(npm list -s --depth=0 | grep firebase-tools | tail -n 1 | sed 's/.*@//g')"
+
+      - name: Cache Firebase Emulator Binaries
+        uses: actions/cache@v2.1.2
+        with:
+          path: ~/.cache/firebase/emulators
+          key: ${{ runner.os }}-firebase-${{ steps.cache-settings.outputs.firebase-tools }}
+
       - name: run test (unit & e2e)
         run: yarn test:dev
         env:

--- a/.github/workflows/test-ci-prod.yaml
+++ b/.github/workflows/test-ci-prod.yaml
@@ -1,15 +1,14 @@
-name: Run Test
-run-name: Test
+name: Run Test <Prod>
+run-name: Test Prod
 
 on:
   push:
     branches: [ main, dev ]
     tags: ["*"]
-  pull_request:
 
 jobs:
   unit-e2e-test:
-    name: Unit and E2E Test
+    name: Unit and E2E Test <Prod>
     runs-on: ubuntu-22.04
     steps:
       - name: checkout repo
@@ -27,7 +26,7 @@ jobs:
           dir: "./packages/backend/"
 
       - name: run test (unit & e2e)
-        run: yarn test:ci
+        run: yarn test:ci-prod
         env:
           GOOGLE_APPLICATION_CREDENTIALS: ./packages/backend/serviceAccountKey.json
           FIREBASE_FIRESTORE_DATABASE_URL: ${{ secrets.FIREBASE_FIRESTORE_DATABASE_URL }}

--- a/package.json
+++ b/package.json
@@ -19,9 +19,10 @@
     "scripts": {
         "build": "lerna run build",
         "pretest": "yarn build",
-        "test": "export GOOGLE_APPLICATION_CREDENTIALS=\"./packages/backend/serviceAccountKey.json\" && jest --config=jest.json --detectOpenHandles --forceExit  --coverage",
-        "test:ci": "jest --config=jest.json --detectOpenHandles --forceExit  --coverage=false",
-        "test:watch": "export GOOGLE_APPLICATION_CREDENTIALS=\"./packages/backend/serviceAccountKey.json\" && jest --config=jest.json --watch --detectOpenHandles --forceExit  --coverage",
+        "test": "yarn test:dev",
+        "test:dev": "NODE_ENV=dev yarn workspace @zkmpc/backend emulator:exec-test",
+        "test:prod": "NODE_ENV=prod export GOOGLE_APPLICATION_CREDENTIALS=\"./packages/backend/serviceAccountKey.json\" && jest --config=jest.json --detectOpenHandles --forceExit --coverage",
+        "test:ci-prod": "NODE_ENV=prod jest --config=jest.json --detectOpenHandles --forceExit --coverage=false",
         "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
         "lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
         "prettier": "prettier -c .",

--- a/packages/actions/test/index.test.ts
+++ b/packages/actions/test/index.test.ts
@@ -72,6 +72,10 @@ describe("Sample e2e", () => {
             .doc(fakeCircuitsData.fakeCircuitSmallNoContributors.uid)
             .delete()
 
+        // TODO: use a listener.
+        // nb. workaround (wait until circuit has been deleted, then delete the ceremony).
+        await sleep(1000)
+
         await adminFirestore.collection(`ceremonies`).doc(fakeCeremoniesData.fakeCeremonyOpenedFixed.uid).delete()
 
         // Remove Auth user.

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -47,7 +47,9 @@
         "firestore:get-indexes": "firebase firestore:indexes > firestore.indexes.json",
         "emulator:serve": "yarn build && firebase emulators:start",
         "emulator:serve-functions": "yarn build && firebase emulators:start --only functions",
-        "emulator:shell": "yarn build && firebase functions:shell"
+        "emulator:shell": "yarn build && firebase functions:shell",
+        "emulator:exec-test": "firebase emulators:exec \"yarn test:emulator\" && kill -9 $(lsof -ti:8085)",
+        "test:emulator": "jest --config=../../jest.json --detectOpenHandles --forceExit --coverage=false"
     },
     "devDependencies": {
         "@firebase/rules-unit-testing": "^2.0.5",


### PR DESCRIPTION
This PR is intended to discriminate between tests executed in production and tests executed in a local environment. In this case, the local environment is the Firebase Emulator. Thus, the Github Action is now splitted into `prod` and `dev`, respectively. The former will be executed in the `dev` and `main` branches of the origin repo while the latter when opening a new PR. This solves the problem of failures of the old `test-ci` which used secrets not accessible for external forks.