### PR TITLE
test(auth): added first tests for authentication

### DIFF
--- a/packages/actions/test/e2e/00-authentication.test.ts
+++ b/packages/actions/test/e2e/00-authentication.test.ts
@@ -94,10 +94,6 @@ describe("Authentication", () => {
         // @todo mock unreachable firebase.
     })
 
-    it("should not be possible to authenticate twice", async () => {
-        // @todo Implement checks to prevent double authentication.
-    })
-
     afterAll(async () => {
         if (user) {
             // Clean user from DB.

--- a/packages/actions/test/e2e/00-authentication.test.ts
+++ b/packages/actions/test/e2e/00-authentication.test.ts
@@ -51,7 +51,6 @@ describe("Authentication", () => {
         expect(currentAuthenticatedUser.emailVerified).to.be.equal(user.data.emailVerified)
         expect(currentAuthenticatedUser.emailVerified).to.be.equal(data?.emailVerified)
         expect(currentAuthenticatedUser.displayName).to.be.null // due to mail/pw provider.
-        // expect(currentAuthenticatedUser.displayName).to.be.equal(data?.displayName)
         expect(currentAuthenticatedUser.photoURL).to.be.null // due to mail/pw provider.
         expect(data?.photoURL).to.be.empty // due to mail/pw provider.
         expect(new Date(String(currentAuthenticatedUser.metadata.creationTime)).valueOf()).to.be.equal(
@@ -67,6 +66,7 @@ describe("Authentication", () => {
         const disabledRecord = await adminAuth.updateUser(user.uid, { disabled: true })
         expect(disabledRecord.disabled).to.be.true
 
+        // Try to authenticate with the disabled user.
         await expect(signInWithEmailAndPassword(userAuth, user.data.email, userPassword)).to.be.rejectedWith(
             "Firebase: Error (auth/user-disabled)."
         )
@@ -79,18 +79,21 @@ describe("Authentication", () => {
     })
 
     it("should not be possible to authenticate with an incorrect password", async () => {
+        // Try to authenticate with the wrong password.
         await expect(signInWithEmailAndPassword(userAuth, user.data.email, "wrongPassword")).to.be.rejectedWith(
             "Firebase: Error (auth/wrong-password)."
         )
     })
 
     it("should not be possible to authenticate with an incorrect email", async () => {
+        // Try to authenticate with the wrong email.
         await expect(signInWithEmailAndPassword(userAuth, "wrongEmail", userPassword)).to.be.rejected
     })
 
     it("should not be possible to authenticate if Firebase is unreachable", async () => {
         // @todo mock unreachable firebase.
     })
+
     it("should not be possible to authenticate twice", async () => {
         // @todo Implement checks to prevent double authentication.
     })

--- a/packages/actions/test/e2e/00-authentication.test.ts
+++ b/packages/actions/test/e2e/00-authentication.test.ts
@@ -85,9 +85,7 @@ describe("Authentication", () => {
     })
 
     it("should not be possible to authenticate with an incorrect email", async () => {
-        await expect(signInWithEmailAndPassword(userAuth, "wrongEmail", userPassword)).to.be.rejectedWith(
-            "Firebase: Error (auth/invalid-email)."
-        )
+        await expect(signInWithEmailAndPassword(userAuth, "wrongEmail", userPassword)).to.be.rejected
     })
 
     it("should not be possible to authenticate if Firebase is unreachable", async () => {

--- a/packages/actions/test/utils/authentication.ts
+++ b/packages/actions/test/utils/authentication.ts
@@ -35,6 +35,7 @@ export const createNewFirebaseUserWithEmailAndPw = async (
  * @param gmailRefreshToken <string> - the GMail refresh token.
  * @dev You should have the GMail APIs for OAuth2.0 must be enabled and configured properly in order to get correct results.
  * @returns <Promise<string>> - return the 6 digits verification code needed to complete the access with Github.
+ * @todo this method will not be used for testing right now. See PR #286 and #289 for info.
  */
 export const getLastGithubVerificationCode = async (
     gmailUserEmail: string,
@@ -78,9 +79,9 @@ export const getLastGithubVerificationCode = async (
 /**
  * Simulate callback to manage the data requested for Github OAuth2.0 device flow.
  * @param verification <Verification> - the data from Github OAuth2.0 device flow.
+ * @todo this method will not be used for testing right now. See PR #286 and #289 for info.
  */
 export const simulateOnVerification = async (verification: Verification): Promise<any> => {
-    // NB. this method will not be used for testing right now. See PR #286 for info.
     // 0.A Prepare data and plugins.
     const { userEmail, githubUserPw, gmailClientId, gmailClientSecret, gmailRedirectUrl, gmailRefreshToken } =
         getAuthenticationConfiguration()
@@ -198,9 +199,9 @@ export const simulateOnVerification = async (verification: Verification): Promis
 /**
  * Simulate callback to cancel authorization for Github OAuth2.0 device flow.
  * @param verification <Verification> - the data from Github OAuth2.0 device flow.
+ * @todo this method will not be used for testing right now. See PR #286 and #289 for info.
  */
 export const simulateCancelledOnVerification = async (verification: Verification): Promise<any> => {
-    // NB. this method will not be used for testing right now. See PR #286 for info.
     // 0.A Prepare data and plugins.
     const { userEmail, githubUserPw, gmailClientId, gmailClientSecret, gmailRedirectUrl, gmailRefreshToken } =
         getAuthenticationConfiguration()
@@ -311,9 +312,9 @@ export const simulateCancelledOnVerification = async (verification: Verification
 /**
  * Simulate callback sending an invalid device code for Github OAuth2.0 device flow.
  * @param verification <Verification> - the data from Github OAuth2.0 device flow.
+ * @todo this method will not be used for testing right now. See PR #286 and #289 for info.
  */
 export const simulateInvalidTokenOnVerification = async (verification: Verification): Promise<any> => {
-    // NB. this method will not be used for testing right now. See PR #286 for info.
     // 0.A Prepare data and plugins.
     const { userEmail, githubUserPw, gmailClientId, gmailClientSecret, gmailRedirectUrl, gmailRefreshToken } =
         getAuthenticationConfiguration()
@@ -418,10 +419,10 @@ export const simulateInvalidTokenOnVerification = async (verification: Verificat
 /**
  * Simulate callback for unreachable GitHub website for Github OAuth2.0 device flow.
  * @param verification <Verification> - the data from Github OAuth2.0 device flow.
+ * @todo this method will not be used for testing right now. See PR #286 and #289 for info.
  */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 export const simulateUnreachablePageOnVerification = async (verification: Verification): Promise<any> => {
-    // NB. this method will not be used for testing right now. See PR #286 for info.
     puppeteerExtra.use(stealthMode())
     puppeteerExtra.use(anonUserAgent({ stripHeadless: true }))
 
@@ -474,6 +475,7 @@ export const simulateUnreachablePageOnVerification = async (verification: Verifi
  * @param userApp <FirebaseApp> - the Firebase user Application instance.
  * @param clientId <string> - the Github client id.
  * @returns <Promise<UserCredential>> - the credential of the user after the handshake with Firebase.
+ * @todo this method will not be used for testing right now. See PR #286 and #289 for info.
  */
 export const authenticateUserWithGithub = async (userApp: FirebaseApp, clientId: string): Promise<UserCredential> => {
     const clientType = "oauth-app"

--- a/packages/actions/test/utils/authentication.ts
+++ b/packages/actions/test/utils/authentication.ts
@@ -196,6 +196,279 @@ export const simulateOnVerification = async (verification: Verification): Promis
 }
 
 /**
+ * Simulate callback to cancel authorization for Github OAuth2.0 device flow.
+ * @param verification <Verification> - the data from Github OAuth2.0 device flow.
+ */
+export const simulateCancelledOnVerification = async (verification: Verification): Promise<any> => {
+    // NB. this method will not be used for testing right now. See PR #286 for info.
+    // 0.A Prepare data and plugins.
+    const { userEmail, githubUserPw, gmailClientId, gmailClientSecret, gmailRedirectUrl, gmailRefreshToken } =
+        getAuthenticationConfiguration()
+    puppeteerExtra.use(stealthMode())
+    puppeteerExtra.use(anonUserAgent({ stripHeadless: true }))
+
+    // 0.B Browser and page.
+    const args = [
+        "--no-sandbox",
+        "--disable-setuid-sandbox",
+        // Get rid of cache and temp files.
+        "--aggressive-cache-discard",
+        "--disable-cache",
+        "--disable-application-cache",
+        "--disable-offline-load-stale-cache",
+        "--disable-gpu-shader-disk-cache",
+        "--media-cache-size=0",
+        "--disk-cache-size=0",
+        // Increase speed and network throughput.
+        "--disable-extensions",
+        "--disable-component-extensions-with-background-pages",
+        "--disable-default-apps",
+        "--mute-audio",
+        "--no-default-browser-check",
+        "--autoplay-policy=user-gesture-required",
+        "--disable-background-timer-throttling",
+        "--disable-backgrounding-occluded-windows",
+        "--disable-notifications",
+        "--disable-background-networking",
+        "--disable-breakpad",
+        "--disable-component-update",
+        "--disable-domain-reliability",
+        "--disable-sync"
+    ]
+
+    // Switch to 'headless: false' to debug using the Chrome browser.
+    const browser = await puppeteerExtra.launch({ args, headless: true, channel: "chrome" })
+    const ghPage = await browser.newPage()
+
+    // 1. Navigate to Github login to execute device flow OAuth.
+    ghPage.goto(verification.verification_uri)
+    await Promise.race([
+        ghPage.waitForNavigation({ waitUntil: "domcontentloaded" }),
+        ghPage.waitForNavigation({ waitUntil: "load" })
+    ])
+
+    // Type data.
+    await ghPage.waitForSelector(`.js-login-field`, { visible: true })
+    await ghPage.waitForSelector(`.js-password-field`, { visible: true })
+
+    await ghPage.type(".js-login-field", userEmail, { delay: 100 })
+    await ghPage.type(".js-password-field", githubUserPw, { delay: 100 })
+
+    // Confirm.
+    await Promise.all([await ghPage.keyboard.press("Enter"), await ghPage.waitForNavigation()])
+
+    await sleep(2000) // 2sec. to receive email.
+
+    if ((await ghPage.$(`.js-verification-code-input-auto-submit`)) !== null) {
+        // 2. Get verification code from GMail using APIs.
+        const verificationCode = await getLastGithubVerificationCode(
+            userEmail,
+            gmailClientId,
+            gmailClientSecret,
+            gmailRedirectUrl,
+            gmailRefreshToken
+        )
+
+        // 1.3 Input verification code and complete sign-in.
+        await ghPage.waitForSelector(`.js-verification-code-input-auto-submit`, { timeout: 10000, visible: true })
+        await ghPage.type(".js-verification-code-input-auto-submit", verificationCode, { delay: 100 })
+        // Confirm.
+        await Promise.all([await ghPage.keyboard.press("Enter"), await ghPage.waitForNavigation()])
+    }
+
+    // 2. Insert code for device activation.
+    // Get input slots for digits besides the fourth ('-' char).
+    const userCode0 = await ghPage.$("#user-code-0")
+    const userCode1 = await ghPage.$("#user-code-1")
+    const userCode2 = await ghPage.$("#user-code-2")
+    const userCode3 = await ghPage.$("#user-code-3")
+    const userCode5 = await ghPage.$("#user-code-5")
+    const userCode6 = await ghPage.$("#user-code-6")
+    const userCode7 = await ghPage.$("#user-code-7")
+    const userCode8 = await ghPage.$("#user-code-8")
+    // Type digits.
+    await userCode0?.type(verification.user_code[0], { delay: 100 })
+    await userCode1?.type(verification.user_code[1], { delay: 100 })
+    await userCode2?.type(verification.user_code[2], { delay: 100 })
+    await userCode3?.type(verification.user_code[3], { delay: 100 })
+    await userCode5?.type(verification.user_code[5], { delay: 100 })
+    await userCode6?.type(verification.user_code[6], { delay: 100 })
+    await userCode7?.type(verification.user_code[7], { delay: 100 })
+    await userCode8?.type(verification.user_code[8], { delay: 100 })
+    // Progress.
+    const continueButton = await ghPage.$('[name="commit"]')
+    await Promise.all([await continueButton?.click(), ghPage.waitForNavigation()])
+
+    // 3. Confirm authorization for association of account and application.
+    await sleep(2000) // wait for authorize button be clickable.
+
+    const cancelButton = await ghPage.$('button[value="0"]')
+    await Promise.all([await cancelButton?.click(), ghPage.waitForNavigation()])
+
+    await browser.close()
+}
+
+/**
+ * Simulate callback sending an invalid device code for Github OAuth2.0 device flow.
+ * @param verification <Verification> - the data from Github OAuth2.0 device flow.
+ */
+export const simulateInvalidTokenOnVerification = async (verification: Verification): Promise<any> => {
+    // NB. this method will not be used for testing right now. See PR #286 for info.
+    // 0.A Prepare data and plugins.
+    const { userEmail, githubUserPw, gmailClientId, gmailClientSecret, gmailRedirectUrl, gmailRefreshToken } =
+        getAuthenticationConfiguration()
+    puppeteerExtra.use(stealthMode())
+    puppeteerExtra.use(anonUserAgent({ stripHeadless: true }))
+
+    // 0.B Browser and page.
+    const args = [
+        "--no-sandbox",
+        "--disable-setuid-sandbox",
+        // Get rid of cache and temp files.
+        "--aggressive-cache-discard",
+        "--disable-cache",
+        "--disable-application-cache",
+        "--disable-offline-load-stale-cache",
+        "--disable-gpu-shader-disk-cache",
+        "--media-cache-size=0",
+        "--disk-cache-size=0",
+        // Increase speed and network throughput.
+        "--disable-extensions",
+        "--disable-component-extensions-with-background-pages",
+        "--disable-default-apps",
+        "--mute-audio",
+        "--no-default-browser-check",
+        "--autoplay-policy=user-gesture-required",
+        "--disable-background-timer-throttling",
+        "--disable-backgrounding-occluded-windows",
+        "--disable-notifications",
+        "--disable-background-networking",
+        "--disable-breakpad",
+        "--disable-component-update",
+        "--disable-domain-reliability",
+        "--disable-sync"
+    ]
+
+    // Switch to 'headless: false' to debug using the Chrome browser.
+    const browser = await puppeteerExtra.launch({ args, headless: true, channel: "chrome" })
+    const ghPage = await browser.newPage()
+
+    // 1. Navigate to Github login to execute device flow OAuth.
+    ghPage.goto(verification.verification_uri)
+    await Promise.race([
+        ghPage.waitForNavigation({ waitUntil: "domcontentloaded" }),
+        ghPage.waitForNavigation({ waitUntil: "load" })
+    ])
+
+    // Type data.
+    await ghPage.waitForSelector(`.js-login-field`, { visible: true })
+    await ghPage.waitForSelector(`.js-password-field`, { visible: true })
+
+    await ghPage.type(".js-login-field", userEmail, { delay: 100 })
+    await ghPage.type(".js-password-field", githubUserPw, { delay: 100 })
+
+    // Confirm.
+    await Promise.all([await ghPage.keyboard.press("Enter"), await ghPage.waitForNavigation()])
+
+    await sleep(2000) // 2sec. to receive email.
+
+    if ((await ghPage.$(`.js-verification-code-input-auto-submit`)) !== null) {
+        // 2. Get verification code from GMail using APIs.
+        const verificationCode = await getLastGithubVerificationCode(
+            userEmail,
+            gmailClientId,
+            gmailClientSecret,
+            gmailRedirectUrl,
+            gmailRefreshToken
+        )
+
+        // 1.3 Input verification code and complete sign-in.
+        await ghPage.waitForSelector(`.js-verification-code-input-auto-submit`, { timeout: 10000, visible: true })
+        await ghPage.type(".js-verification-code-input-auto-submit", verificationCode, { delay: 100 })
+        // Confirm.
+        await Promise.all([await ghPage.keyboard.press("Enter"), await ghPage.waitForNavigation()])
+    }
+
+    // 2. Insert code for device activation.
+    // Get input slots for digits besides the fourth ('-' char).
+    const userCode0 = await ghPage.$("#user-code-0")
+    const userCode1 = await ghPage.$("#user-code-1")
+    const userCode2 = await ghPage.$("#user-code-2")
+    const userCode3 = await ghPage.$("#user-code-3")
+    const userCode5 = await ghPage.$("#user-code-5")
+    const userCode6 = await ghPage.$("#user-code-6")
+    const userCode7 = await ghPage.$("#user-code-7")
+    const userCode8 = await ghPage.$("#user-code-8")
+    // @test Type wrong digits
+    await userCode0?.type("1", { delay: 100 })
+    await userCode1?.type("2", { delay: 100 })
+    await userCode2?.type("3", { delay: 100 })
+    await userCode3?.type("4", { delay: 100 })
+    await userCode5?.type("5", { delay: 100 })
+    await userCode6?.type("6", { delay: 100 })
+    await userCode7?.type("7", { delay: 100 })
+    await userCode8?.type("8", { delay: 100 })
+    // Progress.
+    const continueButton = await ghPage.$('[name="commit"]')
+    await Promise.all([await continueButton?.click(), ghPage.waitForNavigation()])
+
+    await browser.close()
+}
+
+/**
+ * Simulate callback for unreachable GitHub website for Github OAuth2.0 device flow.
+ * @param verification <Verification> - the data from Github OAuth2.0 device flow.
+ */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+export const simulateUnreachablePageOnVerification = async (verification: Verification): Promise<any> => {
+    // NB. this method will not be used for testing right now. See PR #286 for info.
+    puppeteerExtra.use(stealthMode())
+    puppeteerExtra.use(anonUserAgent({ stripHeadless: true }))
+
+    // 0.B Browser and page.
+    const args = [
+        "--no-sandbox",
+        "--disable-setuid-sandbox",
+        // Get rid of cache and temp files.
+        "--aggressive-cache-discard",
+        "--disable-cache",
+        "--disable-application-cache",
+        "--disable-offline-load-stale-cache",
+        "--disable-gpu-shader-disk-cache",
+        "--media-cache-size=0",
+        "--disk-cache-size=0",
+        // Increase speed and network throughput.
+        "--disable-extensions",
+        "--disable-component-extensions-with-background-pages",
+        "--disable-default-apps",
+        "--mute-audio",
+        "--no-default-browser-check",
+        "--autoplay-policy=user-gesture-required",
+        "--disable-background-timer-throttling",
+        "--disable-backgrounding-occluded-windows",
+        "--disable-notifications",
+        "--disable-background-networking",
+        "--disable-breakpad",
+        "--disable-component-update",
+        "--disable-domain-reliability",
+        "--disable-sync"
+    ]
+
+    // Switch to 'headless: false' to debug using the Chrome browser.
+    const browser = await puppeteerExtra.launch({ args, headless: true, channel: "chrome" })
+    const ghPage = await browser.newPage()
+
+    await sleep(2000) // 2sec. to receive email.
+
+    // 1. Navigate to Github login to execute device flow OAuth.
+    ghPage.goto("https://g1thub.com/login/device")
+
+    await sleep(2000)
+
+    await browser.close()
+}
+
+/**
  * Reproduce the Github Device Flow OAuth2.0 and Firebase credential handshake to authenticate a user.
  * @notice This works only in production environment. (nb. we need to address the issue on the 'onVerification' before using this).
  * @param userApp <FirebaseApp> - the Firebase user Application instance.

--- a/packages/actions/test/utils/index.ts
+++ b/packages/actions/test/utils/index.ts
@@ -13,5 +13,8 @@ export {
     createNewFirebaseUserWithEmailAndPw,
     getLastGithubVerificationCode,
     simulateOnVerification,
-    authenticateUserWithGithub
+    authenticateUserWithGithub,
+    simulateCancelledOnVerification,
+    simulateUnreachablePageOnVerification,
+    simulateInvalidTokenOnVerification
 } from "./authentication"

--- a/packages/actions/test/utils/index.ts
+++ b/packages/actions/test/utils/index.ts
@@ -9,12 +9,4 @@ export {
     generatePseudoRandomStringOfNumbers
 } from "./configs"
 
-export {
-    createNewFirebaseUserWithEmailAndPw,
-    getLastGithubVerificationCode,
-    simulateOnVerification,
-    authenticateUserWithGithub,
-    simulateCancelledOnVerification,
-    simulateUnreachablePageOnVerification,
-    simulateInvalidTokenOnVerification
-} from "./authentication"
+export { createNewFirebaseUserWithEmailAndPw } from "./authentication"


### PR DESCRIPTION
Implemented a number of test cases for authentication using GitHub OAuth2 for prod testing and username and password for the Firebase emulator. 
Update: due to some errors with GitHub and Puppeteer, prod testing include more reliable tests with username and password. This is documented on #288 and #282.

fix #281