### PR TITLE
Switch from Github to email/pw authentication for testing

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,6 +21,7 @@
         "no-restricted-syntax": "off",
         "no-console": ["warn", { "allow": ["info", "warn", "error", "log"] }],
         "@typescript-eslint/lines-between-class-members": "off",
+        "@typescript-eslint/no-unused-expressions": "warn",
         "no-param-reassign": "off",
         "jest/expect-expect": "off",
         "no-promise-executor-return": "warn"

--- a/packages/actions/test/data/samples.ts
+++ b/packages/actions/test/data/samples.ts
@@ -11,7 +11,7 @@ const fakeUser1 = generateFakeUser({
     uid: "0000000000000000000000000001",
     data: {
         name: "user1",
-        displayName: undefined,
+        displayName: "user1",
         creationTime: Date.now(),
         lastSignInTime: Date.now() + 1,
         lastUpdated: Date.now() + 2,

--- a/packages/actions/test/e2e/00-authentication.test.ts
+++ b/packages/actions/test/e2e/00-authentication.test.ts
@@ -1,127 +1,60 @@
-import { createOAuthDeviceAuth } from "@octokit/auth-oauth-device"
 import { expect } from "chai"
-import { FirebaseApp } from "firebase/app"
-import { GithubAuthProvider } from "firebase/auth"
-import { getCurrentFirebaseAuthUser, signInToFirebaseWithCredentials } from "../../src/index"
+import { getCurrentFirebaseAuthUser, getDocumentById } from "../../src/index"
 import {
     createNewFirebaseUserWithEmailAndPw,
     deleteAdminApp,
-    envType,
     generatePseudoRandomStringOfNumbers,
-    getAuthenticationConfiguration,
     initializeAdminServices,
     initializeUserServices,
-    simulateOnVerification
+    sleep
 } from "../utils"
-import { TestingEnvironment } from "../../types"
 import { fakeUsersData } from "../data/samples"
 
-/**
+/*
  * E2E authentication tests.
  */
 describe("Authentication", () => {
     // Prepare all necessary data to execute the e2e scenario flow.
-    let firebaseUserApp: FirebaseApp
-    let userEmailAddress: string
-    let userUid: string
+    const user = fakeUsersData.fakeUser1
 
     // Init admin services.
     const { adminFirestore, adminAuth } = initializeAdminServices()
+    const { userApp, userFirestore } = initializeUserServices()
 
-    beforeAll(async () => {
-        // Get and assign configs.
-        const { userApp } = initializeUserServices()
-        firebaseUserApp = userApp
+    it("authenticate a new user using email and password", async () => {
+        // Development workflow: authenticate use through email/pw authentication when using the emulator.
+        const userFirebaseCredentials = await createNewFirebaseUserWithEmailAndPw(
+            userApp,
+            user.data.email,
+            generatePseudoRandomStringOfNumbers(24)
+        )
+
+        // Retrieve the current auth user in Firebase.
+        const currentAuthenticatedUser = getCurrentFirebaseAuthUser(userApp)
+        user.uid = currentAuthenticatedUser.uid
+
+        // Await until data has been written on Firestore data by cloud functions.
+        // TODO: try to retrieve data in a cleaner way (maybe async listener?).
+        await sleep(5000) // 5s delay.
+
+        const userDoc = await getDocumentById(userFirestore, "users", user.uid)
+        const data = userDoc.data()
+
+        expect(currentAuthenticatedUser.email).to.be.equal(user.data.email)
+        expect(currentAuthenticatedUser.email).to.be.equal(data?.email)
+        expect(currentAuthenticatedUser.emailVerified).to.be.equal(user.data.emailVerified)
+        expect(currentAuthenticatedUser.emailVerified).to.be.equal(data?.emailVerified)
+        expect(currentAuthenticatedUser.displayName).to.be.null // due to mail/pw provider.
+        expect(currentAuthenticatedUser.displayName).to.be.equal(data?.displayName)
+        expect(currentAuthenticatedUser.photoURL).to.be.null // due to mail/pw provider.
+        expect(data?.photoURL).to.be.empty // due to mail/pw provider.
+        expect(new Date(String(currentAuthenticatedUser.metadata.creationTime)).valueOf()).to.be.equal(
+            new Date(String(userFirebaseCredentials.user.metadata.creationTime)).valueOf()
+        )
+        expect(new Date(String(currentAuthenticatedUser.metadata.lastSignInTime)).valueOf()).to.be.equal(
+            new Date(String(userFirebaseCredentials.user.metadata.lastSignInTime)).valueOf()
+        )
     })
-
-    if (envType === TestingEnvironment.PRODUCTION)
-        /**
-         * Remote production workflow
-         * These tests are going to simulate the interaction between the user and the Github Device Flow using
-         * a web scraper tool. We have tested only GMail accounts associated to Github.
-         * In fact, to retrieve the OTP verification codes from GMail you'll need to enable the GMail OAuth2.0 APIs.
-         * Also, do not enable 2FA on your Github or GMail account.
-         * Please, configure accordingly the environments.
-         *
-         * NB. USE ONLY TESTING ACCOUNTS, NOT YOUR REAL ACCOUNTS.
-         */
-        describe("Production", () => {
-            let clientId: string
-            const clientType = "oauth-app"
-            const tokenType = "oauth"
-
-            beforeAll(async () => {
-                // Get and assign configs.
-                const { githubClientId, userEmail } = getAuthenticationConfiguration()
-                clientId = githubClientId
-                userEmailAddress = userEmail
-
-                const { userApp } = initializeUserServices()
-                firebaseUserApp = userApp
-            })
-
-            it("authenticate a new user using Github OAuth 2.0 device flow", async () => {
-                // Create OAuth 2.0 with Github.
-                const auth = createOAuthDeviceAuth({
-                    clientType,
-                    clientId,
-                    scopes: ["gist"],
-                    onVerification: simulateOnVerification
-                })
-
-                // Get the access token.
-                const { token } = await auth({
-                    type: tokenType
-                })
-
-                // Get and exchange credentials.
-                const userFirebaseCredentials = GithubAuthProvider.credential(token)
-                await signInToFirebaseWithCredentials(firebaseUserApp, userFirebaseCredentials)
-
-                // Retrieve the current auth user in Firebase.
-                const currentAuthUser = getCurrentFirebaseAuthUser(firebaseUserApp)
-
-                // Then.
-                expect(token).lengthOf(40)
-                expect(token.startsWith("gho_")).to.be.equal(true)
-                expect(currentAuthUser.uid.length > 0).to.be.equal(true)
-                expect(userFirebaseCredentials.accessToken).to.be.equal(token)
-
-                // Anchor for freeing up resources after tests.
-                userUid = currentAuthUser.uid
-            })
-        })
-    /**
-     * Development local workflow
-     * These tests run on the Firebase Emulator. The Authentication service of the emulator do not support
-     * 3rd party OAuth login. Therefore, we are going to use the email and a randomly generated password
-     * to authenticate the user in the emulated environment. This kind of tests do not reproduce any Device Flow
-     * Github or any OAuth 2.0. These tests are useful for quickly test the ceremony workflows besides the authentication.
-     * These tests do not use secrets. Please, refer to the production tests for the real Firebase Authentication service test.
-     */ else
-        describe("Development", () => {
-            beforeAll(async () => {
-                // Get and assign configs.
-                userEmailAddress = fakeUsersData.fakeUser1.data.email
-            })
-
-            it("authenticate a new user using email and password", async () => {
-                // Development workflow: authenticate use through email/pw authentication when using the emulator.
-                const userFirebaseCredentials = await createNewFirebaseUserWithEmailAndPw(
-                    firebaseUserApp,
-                    userEmailAddress,
-                    generatePseudoRandomStringOfNumbers(24)
-                )
-
-                // Retrieve the current auth user in Firebase.
-                const currentAuthUser = getCurrentFirebaseAuthUser(firebaseUserApp)
-                userUid = currentAuthUser.uid
-
-                expect(currentAuthUser.uid.length > 0).to.be.equal(true)
-                expect(userFirebaseCredentials.user.uid).to.be.equal(currentAuthUser.uid)
-                expect(userFirebaseCredentials.user.email).to.be.equal(currentAuthUser.email)
-            })
-        })
 
     it("should not be possible to authenticate twice", async () => {})
 
@@ -136,14 +69,83 @@ describe("Authentication", () => {
     it("should not be possible to authenticate if the user has been disabled from the Authentication service by coordinator", async () => {})
 
     afterAll(async () => {
-        // Finally: revert the state back to pre-given state. This section is executed even if when or then fails.
-        // Clean  user from DB.
-        await adminFirestore.collection("users").doc(userUid).delete()
+        // Clean user from DB.
+        await adminFirestore.collection("users").doc(user.uid).delete()
 
         // Remove Auth user.
-        await adminAuth.deleteUser(userUid)
+        await adminAuth.deleteUser(user.uid)
 
         // Delete admin app.
         await deleteAdminApp()
     })
 })
+
+// Production ready tests using puppeteer.
+// Currently under maintainance due to unknown Github authentication restriction.
+// if (envType === TestingEnvironment.PRODUCTION)
+// /**
+//  * Remote production workflow
+//  * These tests are going to simulate the interaction between the user and the Github Device Flow using
+//  * a web scraper tool. We have tested only GMail accounts associated to Github.
+//  * In fact, to retrieve the OTP verification codes from GMail you'll need to enable the GMail OAuth2.0 APIs.
+//  * Also, do not enable 2FA on your Github or GMail account.
+//  * Please, configure accordingly the environments.
+//  *
+//  * NB. USE ONLY TESTING ACCOUNTS, NOT YOUR REAL ACCOUNTS.
+//  */
+// describe("Production", () => {
+//     let clientId: string
+//     const clientType = "oauth-app"
+//     const tokenType = "oauth"
+
+//     beforeAll(async () => {
+//         // Get and assign configs.
+//         const { githubClientId, userEmail } = getAuthenticationConfiguration()
+//         clientId = githubClientId
+//         userEmailAddress = userEmail
+
+//         const { userApp } = initializeUserServices()
+//         firebaseUserApp = userApp
+//     })
+
+//     it("authenticate a new user using Github OAuth 2.0 device flow", async () => {
+//         // Create OAuth 2.0 with Github.
+//         const auth = createOAuthDeviceAuth({
+//             clientType,
+//             clientId,
+//             scopes: ["gist"],
+//             onVerification: simulateOnVerification
+//         })
+
+//         // Get the access token.
+//         const { token } = await auth({
+//             type: tokenType
+//         })
+
+//         // Get and exchange credentials.
+//         const userFirebaseCredentials = GithubAuthProvider.credential(token)
+//         await signInToFirebaseWithCredentials(firebaseUserApp, userFirebaseCredentials)
+
+//         // Retrieve the current auth user in Firebase.
+//         const currentAuthUser = getCurrentFirebaseAuthUser(firebaseUserApp)
+
+//         // Then.
+//         expect(token).lengthOf(40)
+//         expect(token.startsWith("gho_")).to.be.equal(true)
+//         expect(currentAuthUser.uid.length > 0).to.be.equal(true)
+//         expect(userFirebaseCredentials.accessToken).to.be.equal(token)
+
+//         // Anchor for freeing up resources after tests.
+//         userUid = currentAuthUser.uid
+//     })
+// })
+/**
+ * Email/PW Auth workflow.
+ * These tests run on the Firebase Emulator and on Production (due to Github auth protection rules).
+ * The Authentication service of the emulator do not support 3rd party OAuth login.
+ * Therefore, we are going to use the email and a randomly generated password to authenticate the user
+ * in the emulated environment. This kind of tests do not reproduce any Device Flow Github or any OAuth 2.0.
+ * These tests are useful for quickly test the ceremony workflows besides the authentication.
+ * These tests do not use secrets and do not test the 3rd party workflow.
+ */
+// describe("Development", () => {

--- a/packages/actions/test/utils/authentication.ts
+++ b/packages/actions/test/utils/authentication.ts
@@ -80,6 +80,7 @@ export const getLastGithubVerificationCode = async (
  * @param verification <Verification> - the data from Github OAuth2.0 device flow.
  */
 export const simulateOnVerification = async (verification: Verification): Promise<any> => {
+    // NB. this method will not be used for testing right now. See PR #286 for info.
     // 0.A Prepare data and plugins.
     const { userEmail, githubUserPw, gmailClientId, gmailClientSecret, gmailRedirectUrl, gmailRefreshToken } =
         getAuthenticationConfiguration()
@@ -196,7 +197,7 @@ export const simulateOnVerification = async (verification: Verification): Promis
 
 /**
  * Reproduce the Github Device Flow OAuth2.0 and Firebase credential handshake to authenticate a user.
- * @notice This works only in production environment.
+ * @notice This works only in production environment. (nb. we need to address the issue on the 'onVerification' before using this).
  * @param userApp <FirebaseApp> - the Firebase user Application instance.
  * @param clientId <string> - the Github client id.
  * @returns <Promise<UserCredential>> - the credential of the user after the handshake with Firebase.

--- a/packages/backend/src/functions/auth.ts
+++ b/packages/backend/src/functions/auth.ts
@@ -39,6 +39,7 @@ export const registerAuthUser = functions.auth.user().onCreate(async (user: User
     // Set document (nb. we refer to providerData[0] because we use Github OAuth provider only).
     await userRef.set({
         name: displayName,
+        displayName,
         // Metadata.
         creationTime,
         lastSignInTime,


### PR DESCRIPTION
Remember to enable the email/password as one of the possible sign-in methods in your Firebase dashboard.