### PR TITLE
ci: fix build failure of `npm-publish` job

### DIFF
--- a/.github/workflows/test-ci-prod.yaml
+++ b/.github/workflows/test-ci-prod.yaml
@@ -22,9 +22,9 @@ jobs:
               run: yarn install --frozen-lockfile
 
             - name: build packages
-              run: |
-                  export NODE_OPTIONS="--max_old_space_size=4096"
-                  yarn build
+              run: yarn build
+              env:
+                  NODE_OPTIONS: "--max_old_space_size=4096"
 
             - name: write Firebase service account key (from secrets to json)
               id: create-json
@@ -71,6 +71,9 @@ jobs:
               run: |
                   yarn install --frozen-lockfile
                   yarn build
+              env:
+              NODE_OPTIONS: "--max_old_space_size=4096"
+
             - name: Publish Project
               run: |
                   # Prevent `git commit error` when running `lerna version`


### PR DESCRIPTION
Fixes build failure addressed in https://github.com/quadratic-funding/mpc-phase2-suite/actions/runs/4007632074