### PR TITLE
feat(security rules): implemented Firestore security rules

### DIFF
--- a/packages/actions/test/data/samples.ts
+++ b/packages/actions/test/data/samples.ts
@@ -35,6 +35,20 @@ const fakeUser2 = generateFakeUser({
     }
 })
 
+const fakeUser3 = generateFakeUser({
+    uid: "0000000000000000000000000003",
+    data: {
+        name: "user3",
+        displayName: undefined,
+        creationTime: Date.now(),
+        lastSignInTime: Date.now() + 1,
+        lastUpdated: Date.now() + 2,
+        email: "user3@gmail.com",
+        emailVerified: false,
+        photoURL: undefined
+    }
+})
+
 const fakeCeremonyScheduledFixed = generateFakeCeremony({
     uid: "0000000000000000000A",
     data: {
@@ -257,7 +271,8 @@ const fakeCircuitSmallContributors = generateFakeCircuit({
 
 export const fakeUsersData = {
     fakeUser1,
-    fakeUser2
+    fakeUser2,
+    fakeUser3
 }
 
 export const fakeCeremoniesData = {

--- a/packages/actions/test/unit/security.test.ts
+++ b/packages/actions/test/unit/security.test.ts
@@ -13,7 +13,7 @@ import {
 } from "../utils"
 import { fakeUsersData } from "../data/samples"
 import { getCurrentFirebaseAuthUser } from "../../src"
-import { getDocumentById, queryCollection } from "../../src/helpers/query"
+import { getDocumentById, queryCollection } from "../../src/helpers/database"
 
 chai.use(chaiAsPromised)
 

--- a/packages/actions/test/unit/security.test.ts
+++ b/packages/actions/test/unit/security.test.ts
@@ -1,6 +1,7 @@
 import chai, { expect } from "chai"
 import chaiAsPromised from "chai-as-promised"
 import { getAuth, signInWithEmailAndPassword } from "firebase/auth"
+import { where } from "firebase/firestore"
 import {
     createNewFirebaseUserWithEmailAndPw,
     deleteAdminApp,
@@ -12,7 +13,7 @@ import {
 } from "../utils"
 import { fakeUsersData } from "../data/samples"
 import { getCurrentFirebaseAuthUser } from "../../src"
-import { getDocumentById } from "../../src/helpers/query"
+import { getDocumentById, queryCollection } from "../../src/helpers/query"
 
 chai.use(chaiAsPromised)
 
@@ -85,6 +86,14 @@ describe("Security rules", () => {
         const data = userDoc.data()
         expect(data).to.not.be.null
     })
+
+    it("should allow anyone to query the ceremony collection", async () => {
+        // login as user2
+        await signInWithEmailAndPassword(userAuth, user2.data.email, user2Pwd)
+        // query the ceremonies collection
+        expect(await queryCollection(userFirestore, "ceremonies", [where("description", "!=", "")])).to.not.throw
+    })
+
     afterAll(async () => {
         // Clean user from DB.
         await adminFirestore.collection("users").doc(user1.uid).delete()

--- a/packages/actions/test/unit/security.test.ts
+++ b/packages/actions/test/unit/security.test.ts
@@ -1,0 +1,100 @@
+import chai, { expect } from "chai"
+import chaiAsPromised from "chai-as-promised"
+import { getAuth, signInWithEmailAndPassword } from "firebase/auth"
+import {
+    createNewFirebaseUserWithEmailAndPw,
+    deleteAdminApp,
+    generatePseudoRandomStringOfNumbers,
+    initializeAdminServices,
+    initializeUserServices,
+    sleep,
+    addCoordinatorPrivileges
+} from "../utils"
+import { fakeUsersData } from "../data/samples"
+import { getCurrentFirebaseAuthUser } from "../../src"
+import { getDocumentById } from "../../src/helpers/query"
+
+chai.use(chaiAsPromised)
+
+describe("Security rules", () => {
+    // Init admin services.
+    const { adminFirestore, adminAuth } = initializeAdminServices()
+    const { userApp, userFirestore } = initializeUserServices()
+    const userAuth = getAuth(userApp)
+
+    const user1 = fakeUsersData.fakeUser1
+    const user2 = fakeUsersData.fakeUser2
+    const user3 = fakeUsersData.fakeUser3
+    const user1Pwd = generatePseudoRandomStringOfNumbers(24)
+    const user2Pwd = generatePseudoRandomStringOfNumbers(24)
+    const user3Pwd = generatePseudoRandomStringOfNumbers(24)
+
+    beforeAll(async () => {
+        // create 1st user
+        await createNewFirebaseUserWithEmailAndPw(userApp, user1.data.email, user1Pwd)
+
+        // Retrieve the current auth user in Firebase.
+        let currentAuthenticatedUser = getCurrentFirebaseAuthUser(userApp)
+        user1.uid = currentAuthenticatedUser.uid
+
+        // create 2nd user
+        await createNewFirebaseUserWithEmailAndPw(userApp, user2.data.email, user2Pwd)
+
+        // Retrieve the current auth user in Firebase.
+        currentAuthenticatedUser = getCurrentFirebaseAuthUser(userApp)
+        user2.uid = currentAuthenticatedUser.uid
+        await sleep(5000) // 5s delay.
+
+        // create the coordinator
+        await createNewFirebaseUserWithEmailAndPw(userApp, user3.data.email, user3Pwd)
+        currentAuthenticatedUser = getCurrentFirebaseAuthUser(userApp)
+        user3.uid = currentAuthenticatedUser.uid
+        await sleep(5000) // 5s delay.
+    })
+
+    it("should work as expected and return the data for the same user", async () => {
+        // login as user1
+        await signInWithEmailAndPassword(userAuth, user1.data.email, user1Pwd)
+        const userDoc = await getDocumentById(userFirestore, "users", user1.uid)
+        const data = userDoc.data()
+        expect(data).to.not.be.null
+    })
+
+    it("should not return another user's document", async () => {
+        // login as user2
+        await signInWithEmailAndPassword(userAuth, user2.data.email, user2Pwd)
+        // below should fail because we are trying to retrieve a document from another user.
+        expect(getDocumentById(userFirestore, "users", user1.uid)).to.be.rejectedWith(
+            "Missing or insufficient permissions."
+        )
+    })
+
+    it("should allow the coordinator to read another user's document", async () => {
+        // login as user3
+        await signInWithEmailAndPassword(userAuth, user3.data.email, user3Pwd)
+        // Retrieve the current auth user in Firebase.
+        const currentAuthenticatedUser = getCurrentFirebaseAuthUser(userApp)
+        // sleep
+        await sleep(5000)
+        // add coordinator privileges
+        await addCoordinatorPrivileges(adminAuth, user3.uid)
+        // force refresh
+        await currentAuthenticatedUser.getIdTokenResult(true)
+        // retrieve the document of another user
+        const userDoc = await getDocumentById(userFirestore, "users", user1.uid)
+        const data = userDoc.data()
+        expect(data).to.not.be.null
+    })
+    afterAll(async () => {
+        // Clean user from DB.
+        await adminFirestore.collection("users").doc(user1.uid).delete()
+        await adminFirestore.collection("users").doc(user2.uid).delete()
+        await adminFirestore.collection("users").doc(user3.uid).delete()
+        // Remove Auth user.
+        await adminAuth.deleteUser(user1.uid)
+        await adminAuth.deleteUser(user2.uid)
+        await adminAuth.deleteUser(user3.uid)
+        // Delete admin app.
+        await deleteAdminApp()
+    })
+})

--- a/packages/actions/test/utils/authentication.ts
+++ b/packages/actions/test/utils/authentication.ts
@@ -8,6 +8,7 @@ import { google } from "googleapis"
 import { createOAuthDeviceAuth } from "@octokit/auth-oauth-device"
 import { createUserWithEmailAndPassword, getAuth, GithubAuthProvider, UserCredential } from "firebase/auth"
 import { FirebaseApp } from "firebase/app"
+import { Auth } from "firebase-admin/lib/auth/auth"
 import { signInToFirebaseWithCredentials } from "../../src"
 import { getAuthenticationConfiguration, sleep } from "./configs"
 
@@ -496,4 +497,13 @@ export const authenticateUserWithGithub = async (userApp: FirebaseApp, clientId:
     // Get and exchange credentials.
     const userFirebaseCredentials = GithubAuthProvider.credential(token)
     return signInToFirebaseWithCredentials(userApp, userFirebaseCredentials)
+}
+
+/**
+ * Test function to add coordinator privileges to a user.
+ * @param adminAuth <Auth> - the admin auth instance.
+ * @param userId <string> - the uid of the user to add the privileges to.
+ */
+export const addCoordinatorPrivileges = async (adminAuth: Auth, userId: string): Promise<void> => {
+    await adminAuth.setCustomUserClaims(userId, { coordinator: true })
 }

--- a/packages/actions/test/utils/authentication.ts
+++ b/packages/actions/test/utils/authentication.ts
@@ -500,10 +500,14 @@ export const authenticateUserWithGithub = async (userApp: FirebaseApp, clientId:
 }
 
 /**
- * Test function to add coordinator privileges to a user.
+ * Test function to set custom claims of a user.
  * @param adminAuth <Auth> - the admin auth instance.
  * @param userId <string> - the uid of the user to add the privileges to.
+ * @param claims <{ [key: string]: boolean }> - the claims to set.
+ * @returns
  */
-export const addCoordinatorPrivileges = async (adminAuth: Auth, userId: string): Promise<void> => {
-    await adminAuth.setCustomUserClaims(userId, { coordinator: true })
-}
+export const setCustomClaims = async (
+    adminAuth: Auth,
+    userId: string,
+    claims: { [key: string]: boolean }
+): Promise<void> => adminAuth.setCustomUserClaims(userId, claims)

--- a/packages/actions/test/utils/index.ts
+++ b/packages/actions/test/utils/index.ts
@@ -9,4 +9,4 @@ export {
     generatePseudoRandomStringOfNumbers
 } from "./configs"
 
-export { addCoordinatorPrivileges, createNewFirebaseUserWithEmailAndPw } from "./authentication"
+export { createNewFirebaseUserWithEmailAndPw, setCustomClaims } from "./authentication"

--- a/packages/actions/test/utils/index.ts
+++ b/packages/actions/test/utils/index.ts
@@ -9,4 +9,4 @@ export {
     generatePseudoRandomStringOfNumbers
 } from "./configs"
 
-export { createNewFirebaseUserWithEmailAndPw } from "./authentication"
+export { addCoordinatorPrivileges, createNewFirebaseUserWithEmailAndPw } from "./authentication"

--- a/packages/backend/firestore.rules
+++ b/packages/backend/firestore.rules
@@ -3,22 +3,17 @@ service cloud.firestore {
   match /databases/{database}/documents {
     // Define which users can read and write to the database
     match /users/{userId} {
-      // users can read update and delete their own data and 
-      // coordinator can read, update, delete any user's data
+      // users can read update and delete their own data
       allow read, update, delete: 
         if request.auth != null && 
-        request.auth.uid == userId || 
-        request.auth.token.coordinator;
-      // coordinator can create new users
-      allow create: 
-        if request.auth != null && request.auth.token.coordinator;
+        request.auth.uid == userId;
     }
     // applies to the ceremonies collection and nested collections
     match /ceremonies/{ceremonyId=**} {
       // any authenticated user can read
       allow read: if request.auth != null;
-      // only coordinator can create, update, delete ceremonies
-      allow create, update, delete: 
+      // only coordinator can create, and update ceremonies
+      allow create, update: 
         if request.auth != null && 
         request.auth.token.coordinator;
     }

--- a/packages/backend/firestore.rules
+++ b/packages/backend/firestore.rules
@@ -1,9 +1,22 @@
 rules_version = '2';
-// Allow read/write access on all documents to any user signed in to the application
 service cloud.firestore {
   match /databases/{database}/documents {
-    match /{document=**} {
-      allow read, write: if request.auth != null;
+    // Define which users can read and write to the database
+    match /users/{userId} {
+      // users can read update and delete their own data and coordinator can read, update, delete any user's data
+      allow read, update, delete: 
+        if request.auth != null && 
+        request.auth.uid == userId || 
+        request.auth.token.coordinator;
+      // coordinator can create new users
+      allow create: 
+        if request.auth != null && request.auth.token.coordinator;
+    }
+    match /ceremonies/{ceremonyId} {
+      // any authenticated user can read
+      allow read: if request.auth != null;
+      // only coordinator can create, update, delete ceremonies
+      allow create, update, delete: if request.auth != null && request.auth.token.coordinator;
     }
   }
 }

--- a/packages/backend/firestore.rules
+++ b/packages/backend/firestore.rules
@@ -3,7 +3,8 @@ service cloud.firestore {
   match /databases/{database}/documents {
     // Define which users can read and write to the database
     match /users/{userId} {
-      // users can read update and delete their own data and coordinator can read, update, delete any user's data
+      // users can read update and delete their own data and 
+      // coordinator can read, update, delete any user's data
       allow read, update, delete: 
         if request.auth != null && 
         request.auth.uid == userId || 
@@ -12,11 +13,14 @@ service cloud.firestore {
       allow create: 
         if request.auth != null && request.auth.token.coordinator;
     }
-    match /ceremonies/{ceremonyId} {
+    // applies to the ceremonies collection and nested collections
+    match /ceremonies/{ceremonyId=**} {
       // any authenticated user can read
       allow read: if request.auth != null;
       // only coordinator can create, update, delete ceremonies
-      allow create, update, delete: if request.auth != null && request.auth.token.coordinator;
+      allow create, update, delete: 
+        if request.auth != null && 
+        request.auth.token.coordinator;
     }
   }
 }


### PR DESCRIPTION
Implemented security rules to protect data in the Firestore db. This includes test cases to verify the correctness of the security rules.

- users collection: 
    * authenticated users can read and alter their own data (users collection)
    * coordinator can access everyone's data
- ceremonies collection:
    * any authenticated user can read details about a ceremony
    * coordinator can read and alter a ceremony collection

Useful [read](https://www.fullstackfirebase.com/cloud-firestore/security-rules) to understand Firestore rules.

fix #28