### PR TITLE
fix(lib.utils tests): fixing lib.utils tests which cause a compilation error

### DIFF
--- a/packages/actions/test/unit/lib.utils.test.ts
+++ b/packages/actions/test/unit/lib.utils.test.ts
@@ -13,7 +13,7 @@ describe("Utils", () => {
     })
     describe("extractPrefix", () => {
         it("should return the prefix of a string", () => {
-            expect(extractPrefix(fakeCircuitsData.fakeCircuitSmallNoContributors.data.name)).to.equal(
+            expect(extractPrefix(fakeCircuitsData.fakeCircuitSmallNoContributors.data.name!)).to.equal(
                 fakeCircuitsData.fakeCircuitSmallNoContributors.data.prefix
             )
         })


### PR DESCRIPTION
Fixed lib.utils tests which caused a compilation error due to a change in the custom types.