### PR TITLE
build: fix deployment failure by grouping Cloud Functions

### DIFF
--- a/.github/workflows/test-ci-prod.yaml
+++ b/.github/workflows/test-ci-prod.yaml
@@ -68,7 +68,7 @@ jobs:
                   npm install -g firebase-tools
 
             - name: deploy to Firebase
-              run: firebase deploy --only functions --project prod
+              run: yarn firebase:deploy-functions
               working-directory: packages/backend
               env:
                   GOOGLE_APPLICATION_CREDENTIALS: ./serviceAccountKey.json

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -40,7 +40,7 @@
         "firebase:logout": "firebase logout",
         "firebase:init": "firebase init",
         "firebase:deploy": "yarn firestore:get-indexes && firebase deploy --project prod",
-        "firebase:deploy-functions": "firebase deploy --only functions --project prod",
+        "firebase:deploy-functions": "./scripts/deploy-functions.sh",
         "firebase:deploy-firestore": "yarn firestore:get-indexes && firebase deploy --only firestore --project prod",
         "firebase:deploy-storage": "firebase deploy --only storage --project prod",
         "firebase:log-functions": "firebase functions:log --project prod",

--- a/packages/backend/scripts/deploy-functions.sh
+++ b/packages/backend/scripts/deploy-functions.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+set -o xtrace
+
+npx firebase deploy --only functions:user --project prod
+npx firebase deploy --only functions:ceremony --project prod
+npx firebase deploy --only functions:participant --project prod
+npx firebase deploy --only functions:circuit --project prod
+npx firebase deploy --only functions:storage --project prod
+npx firebase deploy --only functions:timeout --project prod

--- a/packages/backend/src/functions/index.ts
+++ b/packages/backend/src/functions/index.ts
@@ -1,36 +1,10 @@
 import admin from "firebase-admin"
 
-export { registerAuthUser, processSignUpWithCustomClaims } from "./user"
-export {
-    startCeremony,
-    stopCeremony,
-    setupCeremony,
-    initEmptyWaitingQueueForCircuit,
-    finalizeCeremony
-} from "./ceremony"
-export {
-    checkParticipantForCeremony,
-    progressToNextContributionStep,
-    permanentlyStoreCurrentContributionTimeAndHash,
-    temporaryStoreCurrentContributionMultiPartUploadId,
-    temporaryStoreCurrentContributionUploadedChunkData,
-    progressToNextCircuitForContribution,
-    checkAndPrepareCoordinatorForFinalization
-} from "./participant"
-export {
-    coordinateCeremonyParticipant,
-    verifycontribution,
-    refreshParticipantAfterContributionVerification,
-    finalizeCircuit
-} from "./circuit"
-export {
-    createBucket,
-    checkIfObjectExist,
-    generateGetObjectPreSignedUrl,
-    startMultiPartUpload,
-    generatePreSignedUrlsParts,
-    completeMultiPartUpload
-} from "./storage"
-export { checkAndRemoveBlockingContributor, resumeContributionAfterTimeoutExpiration } from "./timeout"
+export * as user from "./user"
+export * as ceremony from "./ceremony"
+export * as participant from "./participant"
+export * as circuit from "./circuit"
+export * as storage from "./storage"
+export * as timeout from "./timeout"
 
 admin.initializeApp()


### PR DESCRIPTION
This PR fixes recent deployment failure:
```
2023-03-21T14:30:51.5403764Z [32m[1m✔ [22m[39m [1m[32mfunctions[checkAndRemoveBlockingContributor(us-central1)][39m[22m Successful update operation.
2023-03-21T14:31:01.3564096Z [32m[1m✔ [22m[39m [1m[32mfunctions[setupCeremony(us-central1)][39m[22m Successful update operation.
2023-03-21T14:31:31.3642507Z Could not create or update Cloud Run service projects/p0tion-ci-environment/locations/us-central1/services/verifycontribution. Could not get Cloud Run service projects/p0tion-ci-environment/locations/us-central1/services/verifycontribution. Deadline Exceeded.
2023-03-21T14:31:31.3668535Z 
2023-03-21T14:31:31.3669338Z Functions deploy had errors with the following functions:
2023-03-21T14:31:31.3670661Z 	verifycontribution(us-central1)
2023-03-21T14:31:31.3676097Z [36m[1mi [22m[39m [1m[36mfunctions: [39m[22mcleaning up build files...
2023-03-21T14:31:31.6669113Z [33m[1m⚠  functions:[22m[39m Unhandled error cleaning up build images. This could result in a small monthly bill if not corrected. You can attempt to delete these images by redeploying or you can delete them manually at https://console.cloud.google.com/artifacts/docker/p0tion-ci-environment/us-central1/gcf-artifacts
2023-03-21T14:31:31.6679040Z 
2023-03-21T14:31:31.6681557Z [1m[31mError:[39m[22m There was an error deploying functions
```
https://github.com/quadratic-funding/mpc-phase2-suite/actions/runs/4480173141/jobs/7875177633


Firebase team recommends to group functions under size 10:
> Important: To avoid running to quota errors and other server errors, limit function group size to 10 or fewer for each deployment operation.
source: https://firebase.google.com/docs/cli#deploy_specific_functions

- [ ] Check if functions call need to be renamed since all functions will have a prefix to its name

Fixes: https://github.com/quadratic-funding/mpc-phase2-suite/issues/194